### PR TITLE
the function showDetailView,when there is no menuInfo,exit the method.

### DIFF
--- a/things-detail-popup-behavior.html
+++ b/things-detail-popup-behavior.html
@@ -73,6 +73,7 @@ Things.DetailPopupBehaviorImpl = {
 	 * @listens grid#things-grid-detail-tap
 	 */
 	showDetailView: function(event) {
+		if (!this.menuInfo) return;
 		if(event.defaultPrevented || !event || !event.detail || (!event.detail[this.menuInfo.id_field] && !event.detail.id)) return;
 
 		if(!this.menuInfo.detail_form_id || this.menuInfo.detail_form_id == 'things-resource-form') {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/40262229/120436161-2e660e00-c3b1-11eb-8de0-64d11714d9a0.png)
![image](https://user-images.githubusercontent.com/40262229/120436374-6e2cf580-c3b1-11eb-84ce-29382b1f77a1.png)

I get a error as shown above when tap the `enable-detail-column` for custom download features because there is **not exsit the menuInfo**. Although it does not affect the custom method, it is better to add the codes to avoid this error message.
